### PR TITLE
fix status text miss order

### DIFF
--- a/httpserver.h
+++ b/httpserver.h
@@ -1026,6 +1026,7 @@ char const * status_text[] = {
   "", "", "", "", "", "", "", "", "", "",
   "", "", "", "", "", "", "", "", "", "",
   "", "", "", "", "", "", "", "", "", "",
+  "", "", "", "", "", "", "", "", "", "",
 
   //300s
   "Multiple Choices", "Moved Permanently", "Found", "See Other", "Not Modified",
@@ -1046,7 +1047,9 @@ char const * status_text[] = {
   "Method Not Allowed", "Not Acceptable", "Proxy Authentication Required",
   "Request Timeout", "Conflict",
 
-  "Gone", "Length Required", "Payload Too Large", "", "", "", "", "", "", "",
+  "Gone", "Length Required", "", "Payload Too Large", "", "", "", "", "", "",
+
+  "", "", "", "", "", "", "", "", "", "",
   "", "", "", "", "", "", "", "", "", "",
   "", "", "", "", "", "", "", "", "", "",
   "", "", "", "", "", "", "", "", "", "",


### PR DESCRIPTION
Currently the status code after 200s have an issue, there are 10 missing entries before 300s and other 10 before 500s. 

Also  `Payload Too Large` should be at 413 not 412. 