### PR TITLE
Allow to listen on specific interface

### DIFF
--- a/httpserver.h
+++ b/httpserver.h
@@ -1690,7 +1690,7 @@ void hs_server_init(http_server_t* serv) {
   serv->timerfd = tfd;
 }
 
-int http_server_listen(http_server_t* serv, const char* ipaddr) {
+int http_server_listen_addr(http_server_t* serv, const char* ipaddr) {
   http_listen(serv, ipaddr);
   struct epoll_event ev_list[1];
   while (1) {
@@ -1701,6 +1701,10 @@ int http_server_listen(http_server_t* serv, const char* ipaddr) {
     }
   }
   return 0;
+}
+
+int http_server_listen(http_server_t* serv) {
+  return http_server_listen_addr(serv, NULL);
 }
 
 void hs_delete_events(http_request_t* request) {


### PR DESCRIPTION
The http_server_listen() and http_server_listen_poll() function
listen by default on all available interfaces. In order to be
able to listen only on a specific interface, the functions
http_server_listen_addr() and http_server_listen_addr_poll()
allow to pass the IP address if the interface to listen on as
second parameter.