### PR TITLE
Add header for bind(...)

### DIFF
--- a/httpserver.h
+++ b/httpserver.h
@@ -329,6 +329,7 @@ int main() {
 #include <limits.h>
 #include <assert.h>
 #include <arpa/inet.h>
+#include <sys/socket.h>
 
 #ifdef KQUEUE
 #include <sys/event.h>
@@ -1017,7 +1018,7 @@ void hs_bind_localhost(int s, struct sockaddr_in* addr, const char* ipaddr, int 
     addr->sin_addr.s_addr = inet_addr(ipaddr);
   }
   addr->sin_port = htons(port);
-  int rc = bind(s, (struct sockaddr *)addr, sizeof(struct sockaddr_in));;
+  int rc = bind(s, (struct sockaddr *)addr, sizeof(struct sockaddr_in));
   if (rc < 0) {
     exit(1);
   }


### PR DESCRIPTION
The bind(...) function requires the `sys/socket.h` header.