### PR TITLE
Set _DEFAULT_SOURCE to ensure SO_REUSEPORT is present

### DIFF
--- a/httpserver.h
+++ b/httpserver.h
@@ -316,6 +316,8 @@ int main() {
 #define KQUEUE
 #endif
 
+#define _DEFAULT_SOURCE
+
 #include <time.h>
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
This resolves an issue with glibc 2.31 I experienced where SO_REUSEPORT
would be missing because glibc only includes linux headers if __USE_MISC
is set which is caused by _DEFAULT_SOURCE in features.h.

To be precise test/main.c wouldn't compile on NixOS with glibc 2.31.