### PR TITLE
#include <netinet/in.h>

### DIFF
--- a/httpserver.h
+++ b/httpserver.h
@@ -1,19 +1,19 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 *
 * MIT License
-* 
+*
 * Copyright (c) 2019 Jeremy Williams
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -330,6 +330,7 @@ int main() {
 #include <assert.h>
 #include <arpa/inet.h>
 #include <sys/socket.h>
+#include <netinet/in.h>
 
 #ifdef KQUEUE
 #include <sys/event.h>
@@ -553,7 +554,7 @@ char const * hs_status_text[] = {
   "", "", "", "", "", "", "", "", "", "",
   "", "", "", "", "", "", "", "", "", "",
   "", "", "", "", "", "", "", "", "", "",
-  
+
   //100s
   "Continue", "Switching Protocols", "", "", "", "", "", "", "", "",
   "", "", "", "", "", "", "", "", "", "",
@@ -1070,7 +1071,7 @@ void hs_reset_timeout(http_request_t* request, int time) {
 void hs_read_and_process_request(http_request_t* request);
 
 void hs_write_response(http_request_t* request) {
-  if (!hs_write_client_socket(request)) { 
+  if (!hs_write_client_socket(request)) {
     HTTP_FLAG_SET(request->flags, HTTP_END_SESSION);
     return;
   }
@@ -1459,7 +1460,7 @@ void grwprintf(grwprintf_t* ctx, char const * fmt, ...) {
     bytes += vsnprintf(ctx->buf + ctx->size, ctx->capacity - ctx->size, fmt, args);
   }
   ctx->size += bytes;
- 
+
   va_end(args);
 }
 


### PR DESCRIPTION
add `<netinet/in.h>` so it compiles on BSD, or it'll complain about `incomplete type 'struct sockaddr_in'`

(sorry my editor removes trailing white spaces and messed up the diff log..)