### PR TITLE
Don't use NOTE_SECONDS (Fix portability)

### DIFF
--- a/httpserver.h
+++ b/httpserver.h
@@ -1581,7 +1581,7 @@ void hs_session_io_cb(struct kevent* ev) {
 void hs_server_init(http_server_t* serv) {
   serv->loop = kqueue();
   struct kevent ev_set;
-  EV_SET(&ev_set, 1, EVFILT_TIMER, EV_ADD | EV_ENABLE, NOTE_SECONDS, 1, serv);
+  EV_SET(&ev_set, 1, EVFILT_TIMER, EV_ADD | EV_ENABLE, 0, 1000, serv);
   kevent(serv->loop, &ev_set, 1, NULL, 0, NULL);
 }
 
@@ -1629,7 +1629,7 @@ int http_server_poll(http_server_t* serv) {
 void hs_add_events(http_request_t* request) {
   struct kevent ev_set[2];
   EV_SET(&ev_set[0], request->socket, EVFILT_READ, EV_ADD, 0, 0, request);
-  EV_SET(&ev_set[1], request->socket, EVFILT_TIMER, EV_ADD | EV_ENABLE, NOTE_SECONDS, 1, request);
+  EV_SET(&ev_set[1], request->socket, EVFILT_TIMER, EV_ADD | EV_ENABLE, 0, 1000, request);
   kevent(request->server->loop, ev_set, 2, NULL, 0, NULL);
 }
 


### PR DESCRIPTION
OpenBSD doesn't have NOTE_SECONDS (expects milliseconds) so it doesn't build: https://man.openbsd.org/kqueue#EVFILT_TIMER

FreeBSD and macOS will use milliseconds if fflags is not set
according to kqueue(2) manpages so this change doesn't break anything:

https://www.freebsd.org/cgi/man.cgi?query=kqueue&sektion=2&apropos=0&manpath=FreeBSD+11.1-RELEASE+and+Ports

https://github.com/apple/darwin-xnu/blob/master/bsd/man/man2/kqueue.2#L602-L605