### PR TITLE
Fix broken connection after interrupted write

### DIFF
--- a/httpserver.h
+++ b/httpserver.h
@@ -525,6 +525,7 @@ void hs_server_init(struct http_server_s* serv);
 void hs_delete_events(struct http_request_s* request);
 void hs_add_events(struct http_request_s* request);
 void hs_add_write_event(struct http_request_s* request);
+void hs_add_read_event(struct http_request_s* request);
 void hs_process_tokens(http_request_t* request);
 
 #ifdef KQUEUE
@@ -1093,6 +1094,7 @@ void hs_write_response(http_request_t* request) {
       request->state = HTTP_SESSION_INIT;
       hs_free_buffer(request);
       hs_reset_timeout(request, HTTP_KEEP_ALIVE_TIMEOUT);
+      hs_add_read_event(request);
     } else {
       HTTP_FLAG_SET(request->flags, HTTP_END_SESSION);
     }
@@ -1750,6 +1752,13 @@ void hs_add_events(http_request_t* request) {
 void hs_add_write_event(http_request_t* request) {
   struct epoll_event ev;
   ev.events = EPOLLOUT | EPOLLET;
+  ev.data.ptr = request;
+  epoll_ctl(request->server->loop, EPOLL_CTL_MOD, request->socket, &ev);
+}
+
+void hs_add_read_event(http_request_t* request) {
+  struct epoll_event ev;
+  ev.events = EPOLLIN | EPOLLET;
   ev.data.ptr = request;
   epoll_ctl(request->server->loop, EPOLL_CTL_MOD, request->socket, &ev);
 }


### PR DESCRIPTION
Fixes #59.

When writing the answer to an HTTP request into the socket, the write might have to proceed in multiple parts. (E.g. if the receiver is not able to receive the data fast enough.) To deal with this situation, the server continues execution after a partial write, but changes the flag on the request's epoll object to trigger once the request's socket becomes writable again. However, once the response is fully written, the flags are not changed back, so that subsequent requests (for a keep-alive connection) do not trigger epoll, resulting in the server missing requests.