### PR TITLE
Remove include of common.h

### DIFF
--- a/src/request_util.h
+++ b/src/request_util.h
@@ -1,8 +1,6 @@
 #ifndef HS_REQUEST_UTIL_H
 #define HS_REQUEST_UTIL_H
 
-#include "common.h"
-
 // http version indicators
 #define HTTP_1_0 0
 #define HTTP_1_1 1


### PR DESCRIPTION
When including `httpserver.h` the build fails with the following error because `common.h` is included without protecting it with `HTTPSERVER_IMPL`. The commit removes the include as it is not necessary.
```
request_util.h:4:10: fatal error: common.h: No such file or directory  
```
